### PR TITLE
refactor: add file scoped namespaces for .cs files

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -10,3 +10,6 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = false
+
+[*.cs]
+csharp_style_namespace_declarations=file_scoped:suggestion


### PR DESCRIPTION
File-scoped namespaces are now the default and recommended coding style in C# projects.

The key advantage of file-scoped namespaces is that they produce cleaner code with less indentation, improving readability.

For new C# projects setting this style as the default in .editorconfig would be ideal to ensure consistency and promote modern best practices.